### PR TITLE
launch: publish MCP package and Builder Challenge

### DIFF
--- a/.github/ISSUE_TEMPLATE/builder_challenge.yml
+++ b/.github/ISSUE_TEMPLATE/builder_challenge.yml
@@ -1,0 +1,80 @@
+name: OmniSim Builder Challenge
+description: Submit a reproducible world, robot task, or externally authored AgentBench task.
+title: "[Builder Challenge] "
+labels: ["builder-challenge", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Build one small, measurable thing and give another person enough evidence to reproduce it. Read the [Builder Challenge guide](https://github.com/omnilink-tech/omnisim/blob/main/BUILDERS.md) before submitting.
+
+  - type: dropdown
+    id: lane
+    attributes:
+      label: Challenge lane
+      options:
+        - First edit
+        - Robot or task
+        - Agent benchmark
+    validations:
+      required: true
+
+  - type: textarea
+    id: result
+    attributes:
+      label: What did you build or test?
+      description: State the intended outcome and what actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Exact reproduction steps
+      description: Include the world or task path, commands, prompt, seed, and any required environment variables without secrets.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Measured evidence
+      description: Give the success criterion, observed values, and a negative control or failure case where the lane requires one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Paste `python -m omnisim doctor` output and name the OS and hardware used.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: artifact
+    attributes:
+      label: Patch, repository, or artifact link
+      placeholder: https://github.com/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Known limitations
+      description: Say what is visual-only, unmeasured, flaky, or outside the claim.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: rights
+    attributes:
+      label: Submission checks
+      options:
+        - label: I have the right to share every submitted asset and have named its license or provenance.
+          required: true
+        - label: I understand that a clean load or screenshot alone does not establish correct physics.
+          required: true

--- a/.github/workflows/publish-omnisim-mcp.yml
+++ b/.github/workflows/publish-omnisim-mcp.yml
@@ -1,0 +1,47 @@
+name: Publish omnisim-mcp
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build and test
+        working-directory: packages/omnisim-mcp
+        run: |
+          python -m pip install --upgrade build pytest ruff twine
+          ruff check .
+          pytest -q
+          python -m build
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: omnisim-mcp-dist
+          path: packages/omnisim-mcp/dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: omnisim-mcp-dist
+          path: dist
+
+      # Configure a PyPI Trusted Publisher for this workflow before running it.
+      # No long-lived API token is stored in the repository or Actions secrets.
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/BUILDERS.md
+++ b/BUILDERS.md
@@ -1,0 +1,70 @@
+# OmniSim Builder Challenge
+
+Build one small, measurable thing in OmniSim and show enough evidence that
+another person can reproduce it. There is no entry fee, deadline, or paid
+prize. Useful entries are linked from the project and may become maintained
+demos, benchmarks, or documentation with the contributor's permission.
+
+The challenge is intentionally not a screenshot contest. A scene can look
+excellent while its robot falls through the floor, its controller never ticks,
+or its success detector measures the wrong thing.
+
+## Choose one lane
+
+### First edit
+
+Start from any shipped demo, make one visible change, and prove the edited
+world loads. This is the right lane for a first contribution and should fit in
+one sitting.
+
+Minimum evidence:
+
+- the exact prompt or commands you used;
+- `python -m omnisim doctor` output;
+- the changed world or a small patch;
+- a screenshot and the load-check command.
+
+### Robot or task
+
+Add one robot, sensor, controller behavior, or bounded task. Define success in
+physical units or an observable state before implementing it.
+
+Minimum evidence:
+
+- model and asset provenance;
+- a deterministic launch command;
+- success and failure criteria;
+- one positive run and one useful negative control;
+- known limitations, including anything that only works visually.
+
+### Agent benchmark
+
+Contribute a simulator-neutral task to
+[`tests/benchmarks/agentbench/`](tests/benchmarks/agentbench/) that asks whether
+an agent can get a real job done from one sentence. This is the most valuable
+lane for researchers: externally authored tasks reduce the benchmark owner's
+task-selection bias.
+
+Minimum evidence:
+
+- a task prompt that does not name a preferred implementation;
+- a grader expressed in observable state or physical units;
+- a fake-simulator test for the harness and grader path;
+- a disclosure of any assets, models, or evaluation data supplied by the
+  contributor.
+
+## How entries are reviewed
+
+Reviewers look for reproducibility, measurement quality, honest limits, and a
+small maintenance surface. Visual polish is welcome but does not replace a
+behavioral check. A result that demonstrates a real engine limitation can be
+as useful as a successful demo.
+
+Use the [Builder Challenge issue form](https://github.com/omnilink-tech/omnisim/issues/new?template=builder_challenge.yml)
+to enter. If you need OmniLink to do the initial porting work, use
+[Request a Sim](https://github.com/omnilink-tech/omnisim/issues/new?template=request_a_sim.yml)
+instead.
+
+Contributions remain under their submitted license and must be compatible with
+the repository's Apache-2.0 distribution. Do not submit private, restricted,
+or ambiguously licensed robot assets.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ direction. Physics is [Newton](https://github.com/newton-physics/newton), the on
 Apache-2.0, with a first-party [MCP server](packages/omnisim-mcp/) for Claude Code and Cursor,
 and a [ROS 2 sidecar](packages/omnisim-ros2/) speaking the `simulation_interfaces` standard.
 
-[**Join the public beta**](BETA.md) · [For research labs](LABS.md) · [Latest release](https://github.com/omnilink-tech/omnisim/releases/latest) ·
+[**Join the public beta**](BETA.md) · [Builder challenge](BUILDERS.md) · [For research labs](LABS.md) · [Latest release](https://github.com/omnilink-tech/omnisim/releases/latest) ·
 [Demos](DEMOS.md) · [Agent entry point](AGENTS.md) · [Protocol](PROTOCOL.md)
 
 [![OmniArm 6 uses depth perception to pick unknown objects in OmniSim](docs/media/videos/omniarm6_universal_pick.gif)](docs/media/videos/omniarm6_universal_pick.mp4)

--- a/packages/omnisim-mcp/README.md
+++ b/packages/omnisim-mcp/README.md
@@ -1,5 +1,7 @@
 # omnisim-mcp
 
+<!-- mcp-name: io.github.omnilink-tech/omnisim -->
+
 **Talk to OmniSim from any MCP client.** A [Model Context Protocol](https://modelcontextprotocol.io)
 server that exposes the OmniSim **World Harness** (author → inspect → screenshot →
 hot-reload) as MCP tools, so Claude Desktop, Cursor, or any MCP-capable agent can drive
@@ -27,7 +29,8 @@ a fresh clone, and under OmniSim's embedded interpreter, with nothing installed.
    # or: python scripts/dev/omnisim_dev.py harness
    ```
 
-2. **Register the MCP server** with your client. Either install it —
+2. **Register the MCP server** with your client. Either install it from this
+   checkout —
 
    ```bash
    pip install -e packages/omnisim-mcp     # provides the `omnisim-mcp` command
@@ -35,6 +38,10 @@ a fresh clone, and under OmniSim's embedded interpreter, with nothing installed.
 
    — or run it straight from source with no install (`python -m omnisim_mcp`, with
    `packages/omnisim-mcp/src` on `PYTHONPATH`).
+
+   The package is prepared for PyPI and the official MCP Registry. Until its
+   first production release is visible there, prefer the checkout command above
+   instead of assuming `pip install omnisim-mcp` is available.
 
    Claude Desktop / Cursor `mcpServers` entry:
 

--- a/packages/omnisim-mcp/pyproject.toml
+++ b/packages/omnisim-mcp/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "omnisim-mcp"
 version = "0.1.0"
 description = "Model Context Protocol server over the OmniSim World Harness — drive world authoring/inspection from Claude Desktop, Cursor, and other MCP clients. Zero runtime dependencies (pure stdlib)."
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [{ name = "OmniLink", email = "info@omnilink-agents.com" }]
 requires-python = ">=3.9"
 keywords = ["omnisim", "mcp", "model-context-protocol", "robotics", "agents", "harness"]
@@ -15,7 +16,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -40,11 +40,11 @@ Issues        = "https://github.com/omnilink-tech/omnisim/issues"
 [project.optional-dependencies]
 dev = ["pytest>=7", "ruff>=0.4"]
 
-[tool.setuptools]
-# Apache-2.0 requires that recipients receive a copy of the licence,
-# so the wheel and sdist must carry it (setuptools also globs LICEN[CS]E* by
-# default; this makes it explicit).
-license-files = ["LICENSE"]
-
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff.lint]
+# The server intentionally catches the broad boundary around each JSON-RPC
+# request so a buggy tool cannot terminate the stdio process. Long adjacent
+# description strings keep the MCP schema readable next to each handler.
+ignore = ["BLE001", "ISC004"]

--- a/packages/omnisim-mcp/server.json
+++ b/packages/omnisim-mcp/server.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.omnilink-tech/omnisim",
+  "title": "OmniSim",
+  "description": "Build, inspect, run, and debug OmniSim robotics worlds through the first-party World Harness.",
+  "repository": {
+    "url": "https://github.com/omnilink-tech/omnisim",
+    "source": "github",
+    "subfolder": "packages/omnisim-mcp"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "omnisim-mcp",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "OmniSim World Harness URL",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "OMNISIM_HARNESS_URL",
+          "default": "http://127.0.0.1:6789"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/omnisim-mcp/src/omnisim_mcp/__init__.py
+++ b/packages/omnisim-mcp/src/omnisim_mcp/__init__.py
@@ -19,7 +19,7 @@ first-party agent-facing HTTP surface (the harness, PROTOCOL.md §world_harness)
 this exposes it to the MCP-standardized agent ecosystem (Claude Desktop, Cursor)
 as a thin, dependency-free stdio proxy.
 """
-from .server import main, TOOLS
+from .server import TOOLS, main
 
 __version__ = "0.1.0"
-__all__ = ["main", "TOOLS", "__version__"]
+__all__ = ["TOOLS", "__version__", "main"]

--- a/packages/omnisim-mcp/tests/test_smoke.py
+++ b/packages/omnisim-mcp/tests/test_smoke.py
@@ -18,18 +18,17 @@ These do NOT need a running harness: the point is to prove the JSON-RPC surface
 is correct and that a dead harness produces a clean isError, never a crash.
 """
 import json
+import sys
+from pathlib import Path
 
-# Allow running this file directly without pip-installing (mirrors the
-# omnisim-bridges tests -- without it a bare `pytest` at the repo root
-# cannot collect this file at all).
-import sys
-from pathlib import Path
-
-PKG_SRC = Path(__file__).resolve().parents[1] / "src"
+# Allow running this file directly without pip-installing (mirrors the
+# omnisim-bridges tests -- without it a bare `pytest` at the repo root
+# cannot collect this file at all).
+PKG_SRC = Path(__file__).resolve().parents[1] / "src"
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
-from omnisim_mcp import server  # noqa: E402
+from omnisim_mcp import server
 
 
 def test_initialize_handshake():


### PR DESCRIPTION
Publishes the validated distribution surfaces for the outreach campaign:

- production-ready omnisim-mcp metadata and a manual Trusted Publishing workflow
- Official MCP Registry server.json metadata
- a reproducibility-first Builder Challenge and issue form
- README discovery links

Validation completed locally on Python 3.12:

- 9 package tests passed
- Ruff passed
- wheel and sdist built successfully
- Twine metadata checks passed
- a clean wheel install completed the MCP initialize handshake

Scope remains explicit: the MCP server proxies the OmniSim World Harness; it does not claim photoreal rendering or proven sim-to-real transfer.